### PR TITLE
Implement plotPixel function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: cytomapper
-Version: 1.1.1
+Version: 1.1.2
 Title: Visualization of highly multiplexed imaging cytometry data in R
 Description: 
     Highly multiplexed imaging cytometry acquires the single-cell expression of

--- a/NEWS
+++ b/NEWS
@@ -108,3 +108,6 @@ Changes in version 0.99.5 (2020-04-17):
 + Corrected typos in docs and vignette
 + Avoid recalculation of min/max values in legend function
 
+Changes in version 1.1.2 (2020-05-19):
++ Added image option to the Shiny (implementation of plotCells() function) 
+

--- a/R/launchShiny.R
+++ b/R/launchShiny.R
@@ -550,7 +550,6 @@ shinyApp(ui=function(request) shiny_ui, server=shiny_server)
                     mask = cur_mask,
                     cell_id = cell_id,
                     img_id = img_id,
-                    colour_by = markerA,,
                     colour_by = markerA,
                     exprs_values = cur_assay)
       } else {
@@ -677,7 +676,7 @@ shinyApp(ui=function(request) shiny_ui, server=shiny_server)
                     colour_by = "selected",
                     colour = list(selected = c("TRUE" = "dark red", "FALSE" = "gray")))
     } else {
-      # TODO
+      cur_mask <- mask[mcols(mask)[,img_id] == sample]
       plotCells(object = cur_object,
                 mask = cur_mask,
                 cell_id = cell_id,

--- a/R/launchShiny.R
+++ b/R/launchShiny.R
@@ -551,9 +551,17 @@ shinyApp(ui=function(request) shiny_ui, server=shiny_server)
                     cell_id = cell_id,
                     img_id = img_id,
                     colour_by = markerA,,
+                    colour_by = markerA,
                     exprs_values = cur_assay)
       } else {
-        # TODO
+            cur_mask <- mask[mcols(mask)[,img_id] == sample]
+            cur_image <- image[mcols(image)[,img_id] == sample]
+            plotPixels(image = cur_image,
+                    object = cur_object,
+                    mask = cur_mask,
+                    cell_id = cell_id,
+                    img_id = img_id,
+                    colour_by = markerA)
       }
 
     }
@@ -567,7 +575,14 @@ shinyApp(ui=function(request) shiny_ui, server=shiny_server)
                     colour_by = c(markerA, markerB),
                     exprs_values = cur_assay)
       } else {
-        # TODO
+        cur_mask <- mask[mcols(mask)[,img_id] == sample]
+        cur_image <- image[mcols(image)[,img_id] == sample]
+        plotPixels(image = cur_image,
+                   object = cur_object,
+                   mask = cur_mask,
+                   cell_id = cell_id,
+                   img_id = img_id,
+                   colour_by = c(markerA, markerB))
       }
     }
 
@@ -663,6 +678,12 @@ shinyApp(ui=function(request) shiny_ui, server=shiny_server)
                     colour = list(selected = c("TRUE" = "dark red", "FALSE" = "gray")))
     } else {
       # TODO
+      plotCells(object = cur_object,
+                mask = cur_mask,
+                cell_id = cell_id,
+                img_id = img_id,
+                outline_by = "selected",
+                colour = list(selected = c("TRUE" = "dark red", "FALSE" = "gray")))
     }
   })
 

--- a/R/launchShiny.R
+++ b/R/launchShiny.R
@@ -681,7 +681,7 @@ shinyApp(ui=function(request) shiny_ui, server=shiny_server)
                 mask = cur_mask,
                 cell_id = cell_id,
                 img_id = img_id,
-                outline_by = "selected",
+                colour_by = "selected",
                 colour = list(selected = c("TRUE" = "dark red", "FALSE" = "gray")))
     }
   })


### PR DESCRIPTION
It is now possible to print the pixel information when gating on cells. The selected cells are visualized using the `plotCells` function. Maybe it would be easier to outline the selected cells on the output generated by the `plotPixels` function but that would require changing the shiny code since the marker information is not stored in that segment of the code. 