### PR TITLE
Fix_Bioc_3.19_release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: cytomapper
-Version: 1.15.2
+Version: 1.15.3
 Title: Visualization of highly multiplexed imaging data in R
 Description: 
     Highly multiplexed imaging acquires the single-cell expression of
@@ -67,5 +67,5 @@ biocViews: ImmunoOncology, Software, SingleCell, OneChannel, TwoChannel, Multipl
 VignetteBuilder: knitr
 URL: https://github.com/BodenmillerGroup/cytomapper
 BugReports: https://github.com/BodenmillerGroup/cytomapper/issues
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Encoding: UTF-8

--- a/NEWS
+++ b/NEWS
@@ -192,3 +192,6 @@ Changes in version 1.15.1 (2023-12-10):
 
 Changes in version 1.15.2 (2023-12-13):
 + change of package maintenance to Lasse Meyer
+
+Changes in version 1.15.3 (2024-03-13):
++ measureObject fixes for Bioc 3.19 release

--- a/R/measureObjects.R
+++ b/R/measureObjects.R
@@ -254,8 +254,8 @@ measureObjects <- function(mask,
     cur_colData <- colData(object)
     cur_df <- cbind(mcols(image), mcols(mask))
     cur_df <- cur_df[,unique(names(cur_df)), drop=FALSE]
-    cur_colData <- merge(as.data.frame(cur_colData), 
-                         as.data.frame(cur_df), 
+    cur_colData <- merge(as.data.frame(as.matrix(cur_colData)), 
+                         as.data.frame(as.matrix(cur_df)), 
                          by = img_id, sort = FALSE)
     colData(object) <- as(cur_colData, "DataFrame")
     

--- a/R/measureObjects.R
+++ b/R/measureObjects.R
@@ -78,13 +78,13 @@
 #' haralick (\code{h.}) features. Default features are the following:
 #'
 #' \itemize{
-#' \item{s.area}{object size in pixels}
-#' \item{s.radius.mean}{mean object radius in pixels}
-#' \item{m.cx}{x centroid position of object}
-#' \item{m.cy}{y centroid position of object}
-#' \item{m.majoraxis}{major axis length in pixels of elliptical fit}
-#' \item{m.eccentricity}{elliptical eccentricity. 1 meaning straight line and 0
-#' meaning circle.}
+#' \item s.area - object size in pixels
+#' \item s.radius.mean - mean object radius in pixels
+#' \item m.cx - x centroid position of object
+#' \item m.cy - y centroid position of object
+#' \item m.majoraxis - major axis length in pixels of elliptical fit
+#' \item m.eccentricity - elliptical eccentricity. 1 meaning straight line and 0
+#' meaning circle.
 #' }
 #'
 #' @section Computing quantiles:

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Nils Eling, Nicolas Damond, Tobias Hoch, Bernd Bodenmiller (2020). cytomapper: a
 
 [Tobias Hoch](https://github.com/toobiwankenobi)
 
+## Maintainer
+
+[Lasse Meyer](https://github.com/lassedochreden)
 
 ## References
 

--- a/man/measureObjects.Rd
+++ b/man/measureObjects.Rd
@@ -114,13 +114,13 @@ whether these features correspond to shape (\code{s.}), moment (\code{m.}) or
 haralick (\code{h.}) features. Default features are the following:
 
 \itemize{
-\item{s.area}{object size in pixels}
-\item{s.radius.mean}{mean object radius in pixels}
-\item{m.cx}{x centroid position of object}
-\item{m.cy}{y centroid position of object}
-\item{m.majoraxis}{major axis length in pixels of elliptical fit}
-\item{m.eccentricity}{elliptical eccentricity. 1 meaning straight line and 0
-meaning circle.}
+\item s.area - object size in pixels
+\item s.radius.mean - mean object radius in pixels
+\item m.cx - x centroid position of object
+\item m.cy - y centroid position of object
+\item m.majoraxis - major axis length in pixels of elliptical fit
+\item m.eccentricity - elliptical eccentricity. 1 meaning straight line and 0
+meaning circle.
 }
 }
 


### PR DESCRIPTION
`measureObjects` fixes for BioC release 3.19. 